### PR TITLE
feat: Pull Request Reviews

### DIFF
--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -82,6 +82,16 @@ func (d *Datasource) HandlePullRequestsQuery(ctx context.Context, query *models.
 	return GetPullRequestsInRange(ctx, d.client, opt, req.TimeRange.From, req.TimeRange.To)
 }
 
+// HandlePullRequestsQuery is the query handler for listing GitHub PullRequests
+func (d *Datasource) HandleReviewsQuery(ctx context.Context, query *models.PullRequestsQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.PullRequestOptionsWithRepo(query.Options, query.Owner, query.Repository)
+
+	if req.TimeRange.From.Unix() <= 0 && req.TimeRange.To.Unix() <= 0 {
+		return GetAllPullRequestReviews(ctx, d.client, opt)
+	}
+	return GetPullRequestReviewsInRange(ctx, d.client, opt, req.TimeRange.From, req.TimeRange.To)
+}
+
 // HandleContributorsQuery is the query handler for listing GitHub Contributors
 func (d *Datasource) HandleContributorsQuery(ctx context.Context, query *models.ContributorsQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	opt := models.ListContributorsOptions{

--- a/pkg/github/pull_request_reviews.go
+++ b/pkg/github/pull_request_reviews.go
@@ -1,0 +1,134 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/pkg/errors"
+	"github.com/shurcooL/githubv4"
+)
+
+// QueryListPullRequests lists all pull requests in a repository
+//
+//		{
+//		  search(query: "is:pr repo:grafana/grafana merged:2020-08-19..*", type: ISSUE, first: 100) {
+//		    nodes {
+//		      ... on PullRequest {
+//	         reviews(first: 100) {
+//
+//
+//		      }
+//		  }
+//		}
+type QueryListPullRequestReviews struct {
+	Search struct {
+		Nodes []struct {
+			Reviews struct {
+				Nodes []struct {
+					Review Review `graphql:"... on PullRequestReview"`
+				}
+			} `graphql:"reviews(first: 100)"`
+		}
+		PageInfo models.PageInfo
+	} `graphql:"search(query: $query, type: ISSUE, first: 100, after: $cursor)"`
+}
+
+type ReviewComments struct {
+	TotalCount int64
+}
+
+type ReviewAuthor struct {
+	User models.User `graphql:"... on User"`
+}
+
+type Review struct {
+	Author   ReviewAuthor
+	State    githubv4.PullRequestReviewState
+	Comments ReviewComments `graphsql:"comments(first: 0)"`
+}
+
+// PullRequestReviews is a list of GitHub Pull Request Reviews
+type PullRequestReviews []Review
+
+// Frames coverts the list of Pull Request Reviews to a Grafana DataFrame
+func (r PullRequestReviews) Frames() data.Frames {
+	frame := data.NewFrame(
+		"pull_request_reviews",
+		data.NewField("state", nil, []string{}),
+		data.NewField("author_name", nil, []string{}),
+		data.NewField("author_login", nil, []string{}),
+		data.NewField("author_company", nil, []string{}),
+		data.NewField("comment_count", nil, []int64{}),
+	)
+
+	for _, v := range r {
+		frame.AppendRow(
+			string(v.State),
+			v.Author.User.Name,
+			v.Author.User.Login,
+			v.Author.User.Company,
+			v.Comments.TotalCount,
+		)
+	}
+
+	return data.Frames{frame}
+}
+
+// GetAllPullRequestReviews uses the graphql search endpoint API to search all pull requests in the repository
+// and all reviews for those pull requests.
+func GetAllPullRequestReviews(ctx context.Context, client models.Client, opts models.ListPullRequestsOptions) (PullRequestReviews, error) {
+	var (
+		variables = map[string]interface{}{
+			"cursor": (*githubv4.String)(nil),
+			"query":  githubv4.String(buildQuery(opts)),
+		}
+
+		pullRequestReviews = PullRequestReviews{}
+	)
+
+	for {
+		q := &QueryListPullRequestReviews{}
+		if err := client.Query(ctx, q, variables); err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		reviews := make(PullRequestReviews, 0)
+		for _, pr := range q.Search.Nodes {
+			for _, v := range pr.Reviews.Nodes {
+				reviews = append(reviews, v.Review)
+			}
+		}
+
+		pullRequestReviews = append(pullRequestReviews, reviews...)
+
+		if !q.Search.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = q.Search.PageInfo.EndCursor
+	}
+
+	return pullRequestReviews, nil
+}
+
+// GetPullRequestReviewsInRange uses the graphql search endpoint API to find pull request reviews in the given time range.
+func GetPullRequestReviewsInRange(ctx context.Context, client models.Client, opts models.ListPullRequestsOptions, from time.Time, to time.Time) (PullRequestReviews, error) {
+	var q string
+
+	if opts.TimeField != models.PullRequestNone {
+		q = fmt.Sprintf("%s:%s..%s", opts.TimeField.String(), from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+
+	if opts.Query != nil {
+		q = fmt.Sprintf("%s %s", *opts.Query, q)
+	}
+
+	return GetAllPullRequestReviews(ctx, client, models.ListPullRequestsOptions{
+		Repository: opts.Repository,
+		Owner:      opts.Owner,
+		TimeField:  opts.TimeField,
+		Query:      &q,
+	})
+}

--- a/pkg/github/pull_request_reviews_handler.go
+++ b/pkg/github/pull_request_reviews_handler.go
@@ -1,0 +1,24 @@
+package github
+
+import (
+	"context"
+
+	"github.com/grafana/github-datasource/pkg/dfutil"
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func (s *QueryHandler) handleReviewsQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+	query := &models.PullRequestsQuery{}
+	if err := UnmarshalQuery(q.JSON, query); err != nil {
+		return *err
+	}
+	return dfutil.FrameResponseWithError(s.Datasource.HandleReviewsQuery(ctx, query, q))
+}
+
+// HandlePullRequests handles the plugin query for github PullRequests
+func (s *QueryHandler) HandlePullRequestReviews(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return &backend.QueryDataResponse{
+		Responses: processQueries(ctx, req, s.handleReviewsQuery),
+	}, nil
+}

--- a/pkg/github/pull_request_reviews_handler.go
+++ b/pkg/github/pull_request_reviews_handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func (s *QueryHandler) handleReviewsQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+func (s *QueryHandler) handlePullRequestReviewsQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
 	query := &models.PullRequestsQuery{}
 	if err := UnmarshalQuery(q.JSON, query); err != nil {
 		return *err
@@ -19,6 +19,6 @@ func (s *QueryHandler) handleReviewsQuery(ctx context.Context, q backend.DataQue
 // HandlePullRequests handles the plugin query for github PullRequests
 func (s *QueryHandler) HandlePullRequestReviews(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	return &backend.QueryDataResponse{
-		Responses: processQueries(ctx, req, s.handleReviewsQuery),
+		Responses: processQueries(ctx, req, s.handlePullRequestReviewsQuery),
 	}, nil
 }

--- a/pkg/github/pull_request_reviews_test.go
+++ b/pkg/github/pull_request_reviews_test.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/github-datasource/pkg/testutil"
+	"github.com/shurcooL/githubv4"
+)
+
+func TestListPullRequestReviews(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		opts = models.ListPullRequestsOptions{
+			Repository: "grafana",
+			Owner:      "grafana",
+			TimeField:  models.PullRequestClosedAt,
+		}
+	)
+
+	testVariables := testutil.GetTestVariablesFunction("query", "prCursor", "reviewCursor")
+
+	client := testutil.NewTestClient(t,
+		testVariables,
+		testutil.GetTestQueryFunction(&QueryListPullRequestReviews{}),
+	)
+
+	_, err := GetPullRequestReviewsInRange(ctx, client, opts, time.Now().Add(-30*24*time.Hour), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPullRequestReviewsDataFrame(t *testing.T) {
+	openedAt, err := time.Parse(time.RFC3339, "2020-08-25T16:21:56+00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstUser := models.User{
+		ID:      "1",
+		Login:   "testUser",
+		Name:    "Test User",
+		Company: "ACME corp",
+		Email:   "user@example.com",
+	}
+	secondUser := models.User{
+		ID:      "2",
+		Login:   "testUser2",
+		Name:    "Second User",
+		Company: "ACME corp",
+		Email:   "user2@example.com",
+	}
+	thirdUser := models.User{
+		ID:      "3",
+		Login:   "testUser3",
+		Name:    "Third User",
+		Company: "ACME corp",
+		Email:   "user3@example.com",
+	}
+
+	pullRequestReviews := PullRequestReviews{
+		{
+			Number: 1,
+			Title:  "PullRequest #1",
+			URL:    "https://github.com/grafana/github-datasource/pulls/1",
+			State:  githubv4.PullRequestStateOpen,
+			Author: Author{
+				User: firstUser,
+			},
+			Repository: Repository{
+				NameWithOwner: "grafana/github-datasource",
+			},
+			Reviews: []Review{
+				{
+					URL:   "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+					State: githubv4.PullRequestReviewStateApproved,
+					Author: Author{
+						User: secondUser,
+					},
+					CreatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					UpdatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					CommentsCount: 10,
+				},
+				{
+					URL:   "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+					State: githubv4.PullRequestReviewStateApproved,
+					Author: Author{
+						User: thirdUser,
+					},
+					CreatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					UpdatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					CommentsCount: 1,
+				},
+			},
+		},
+		{
+			Number: 2,
+			Title:  "PullRequest #2",
+			URL:    "https://github.com/grafana/github-datasource/pulls/2",
+			State:  githubv4.PullRequestStateOpen,
+			Author: Author{
+				User: secondUser,
+			},
+			Repository: Repository{
+				NameWithOwner: "grafana/github-datasource",
+			},
+			Reviews: []Review{
+				{
+					URL:   "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+					State: githubv4.PullRequestReviewStateApproved,
+					Author: Author{
+						User: firstUser,
+					},
+					CreatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					UpdatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					CommentsCount: 19,
+				},
+			},
+		},
+		{
+			Number: 3,
+			Title:  "PullRequest #2",
+			URL:    "https://github.com/grafana/github-datasource/pulls/3",
+			State:  githubv4.PullRequestStateOpen,
+			Author: Author{
+				User: secondUser,
+			},
+			Repository: Repository{
+				NameWithOwner: "grafana/github-datasource",
+			},
+			Reviews: []Review{
+				{
+					URL:   "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+					State: githubv4.PullRequestReviewStateApproved,
+					Author: Author{
+						User: firstUser,
+					},
+					CreatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					UpdatedAt: githubv4.DateTime{
+						Time: openedAt,
+					},
+					CommentsCount: 1,
+				},
+			},
+		},
+	}
+
+	testutil.CheckGoldenFramer(t, "pull_request_reviews", pullRequestReviews)
+}

--- a/pkg/github/query_handler.go
+++ b/pkg/github/query_handler.go
@@ -47,6 +47,7 @@ func GetQueryHandlers(s *QueryHandler) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypeContributors, s.HandleContributors)
 	mux.HandleFunc(models.QueryTypeLabels, s.HandleLabels)
 	mux.HandleFunc(models.QueryTypePullRequests, s.HandlePullRequests)
+	mux.HandleFunc(models.QueryTypePullRequestReviews, s.HandlePullRequestReviews)
 	mux.HandleFunc(models.QueryTypeReleases, s.HandleReleases)
 	mux.HandleFunc(models.QueryTypeTags, s.HandleTags)
 	mux.HandleFunc(models.QueryTypePackages, s.HandlePackages)

--- a/pkg/github/testdata/pull_request_reviews.golden.jsonc
+++ b/pkg/github/testdata/pull_request_reviews.golden.jsonc
@@ -1,0 +1,268 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: pull_request_reviews
+//  Dimensions: 18 Fields by 4 Rows
+//  +---------------------------+--------------------------+--------------------------+------------------------------------------------------+--------------------------------+---------------------------------+---------------------------------+-----------------------------------+---------------------------+--------------------------+---------------------------+---------------------------+-----------------------------+----------------------------------------------------------------------------------+--------------------+----------------------------+---------------------------------+---------------------------------+
+//  | Name: pull_request_number | Name: pull_request_title | Name: pull_request_state | Name: pull_request_url                               | Name: pull_request_author_name | Name: pull_request_author_login | Name: pull_request_author_email | Name: pull_request_author_company | Name: repository          | Name: review_author_name | Name: review_author_login | Name: review_author_email | Name: review_author_company | Name: review_url                                                                 | Name: review_state | Name: review_comment_count | Name: review_updated_at         | Name: review_created_at         |
+//  | Labels:                   | Labels:                  | Labels:                  | Labels:                                              | Labels:                        | Labels:                         | Labels:                         | Labels:                           | Labels:                   | Labels:                  | Labels:                   | Labels:                   | Labels:                     | Labels:                                                                          | Labels:            | Labels:                    | Labels:                         | Labels:                         |
+//  | Type: []int64             | Type: []string           | Type: []string           | Type: []string                                       | Type: []string                 | Type: []string                  | Type: []string                  | Type: []string                    | Type: []string            | Type: []string           | Type: []string            | Type: []string            | Type: []string              | Type: []string                                                                   | Type: []string     | Type: []int64              | Type: []time.Time               | Type: []time.Time               |
+//  +---------------------------+--------------------------+--------------------------+------------------------------------------------------+--------------------------------+---------------------------------+---------------------------------+-----------------------------------+---------------------------+--------------------------+---------------------------+---------------------------+-----------------------------+----------------------------------------------------------------------------------+--------------------+----------------------------+---------------------------------+---------------------------------+
+//  | 1                         | PullRequest #1           | OPEN                     | https://github.com/grafana/github-datasource/pulls/1 | Test User                      | testUser                        | user@example.com                | ACME corp                         | grafana/github-datasource | Second User              | testUser2                 | user2@example.com         | ACME corp                   | https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074 | APPROVED           | 10                         | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:21:56 +0000 +0000 |
+//  | 1                         | PullRequest #1           | OPEN                     | https://github.com/grafana/github-datasource/pulls/1 | Test User                      | testUser                        | user@example.com                | ACME corp                         | grafana/github-datasource | Third User               | testUser3                 | user3@example.com         | ACME corp                   | https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074 | APPROVED           | 1                          | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:21:56 +0000 +0000 |
+//  | 2                         | PullRequest #2           | OPEN                     | https://github.com/grafana/github-datasource/pulls/2 | Second User                    | testUser2                       | user2@example.com               | ACME corp                         | grafana/github-datasource | Test User                | testUser                  | user@example.com          | ACME corp                   | https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074 | APPROVED           | 19                         | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:21:56 +0000 +0000 |
+//  | 3                         | PullRequest #2           | OPEN                     | https://github.com/grafana/github-datasource/pulls/3 | Second User                    | testUser2                       | user2@example.com               | ACME corp                         | grafana/github-datasource | Test User                | testUser                  | user@example.com          | ACME corp                   | https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074 | APPROVED           | 1                          | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:21:56 +0000 +0000 |
+//  +---------------------------+--------------------------+--------------------------+------------------------------------------------------+--------------------------------+---------------------------------+---------------------------------+-----------------------------------+---------------------------+--------------------------+---------------------------+---------------------------+-----------------------------+----------------------------------------------------------------------------------+--------------------+----------------------------+---------------------------------+---------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "pull_request_reviews",
+        "fields": [
+          {
+            "name": "pull_request_number",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            }
+          },
+          {
+            "name": "pull_request_title",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_state",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_url",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_author_name",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_author_login",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_author_email",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "pull_request_author_company",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "repository",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_author_name",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_author_login",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_author_email",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_author_company",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_url",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_state",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "review_comment_count",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            }
+          },
+          {
+            "name": "review_updated_at",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "review_created_at",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1,
+            1,
+            2,
+            3
+          ],
+          [
+            "PullRequest #1",
+            "PullRequest #1",
+            "PullRequest #2",
+            "PullRequest #2"
+          ],
+          [
+            "OPEN",
+            "OPEN",
+            "OPEN",
+            "OPEN"
+          ],
+          [
+            "https://github.com/grafana/github-datasource/pulls/1",
+            "https://github.com/grafana/github-datasource/pulls/1",
+            "https://github.com/grafana/github-datasource/pulls/2",
+            "https://github.com/grafana/github-datasource/pulls/3"
+          ],
+          [
+            "Test User",
+            "Test User",
+            "Second User",
+            "Second User"
+          ],
+          [
+            "testUser",
+            "testUser",
+            "testUser2",
+            "testUser2"
+          ],
+          [
+            "user@example.com",
+            "user@example.com",
+            "user2@example.com",
+            "user2@example.com"
+          ],
+          [
+            "ACME corp",
+            "ACME corp",
+            "ACME corp",
+            "ACME corp"
+          ],
+          [
+            "grafana/github-datasource",
+            "grafana/github-datasource",
+            "grafana/github-datasource",
+            "grafana/github-datasource"
+          ],
+          [
+            "Second User",
+            "Third User",
+            "Test User",
+            "Test User"
+          ],
+          [
+            "testUser2",
+            "testUser3",
+            "testUser",
+            "testUser"
+          ],
+          [
+            "user2@example.com",
+            "user3@example.com",
+            "user@example.com",
+            "user@example.com"
+          ],
+          [
+            "ACME corp",
+            "ACME corp",
+            "ACME corp",
+            "ACME corp"
+          ],
+          [
+            "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+            "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+            "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074",
+            "https://github.com/grafana/github-datasource/pull/1#pullrequestreview-2461579074"
+          ],
+          [
+            "APPROVED",
+            "APPROVED",
+            "APPROVED",
+            "APPROVED"
+          ],
+          [
+            10,
+            1,
+            19,
+            1
+          ],
+          [
+            1598372516000,
+            1598372516000,
+            1598372516000,
+            1598372516000
+          ],
+          [
+            1598372516000,
+            1598372516000,
+            1598372516000,
+            1598372516000
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -13,6 +13,8 @@ const (
 	QueryTypeReleases = "Releases"
 	// QueryTypePullRequests is used when querying pull requests in a GitHub repository
 	QueryTypePullRequests = "Pull_Requests"
+	// QueryTypePullRequestReviews is used when querying pull request reviews in a GitHub repository
+	QueryTypePullRequestReviews = "Pull_Request_Reviews"
 	// QueryTypeLabels is used when querying labels in a GitHub repository
 	QueryTypeLabels = "Labels"
 	// QueryTypeRepositories is used when querying for a GitHub repository
@@ -50,6 +52,12 @@ type Query struct {
 
 // PullRequestsQuery is used when querying for GitHub Pull Requests
 type PullRequestsQuery struct {
+	Query
+	Options ListPullRequestsOptions `json:"options"`
+}
+
+// PullRequestsQuery is used when querying for GitHub Pull Requests
+type PullRequestReviewsQuery struct {
 	Query
 	Options ListPullRequestsOptions `json:"options"`
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export enum QueryType {
   Tags = 'Tags',
   Releases = 'Releases',
   Pull_Requests = 'Pull_Requests',
+  Pull_Request_Reviews = 'Pull_Request_Reviews',
   Labels = 'Labels',
   Repositories = 'Repositories',
   Organizations = 'Organizations',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -10,6 +10,7 @@ export interface RepositoryOptions {
 export interface GitHubQuery extends Indexable, DataQuery, RepositoryOptions {
   options?:
     | PullRequestsOptions
+    | PullRequestReviewsOptions
     | ReleasesOptions
     | LabelsOptions
     | TagsOptions
@@ -36,6 +37,11 @@ export interface ReleasesOptions extends Indexable {}
 export interface TagsOptions extends Indexable {}
 
 export interface PullRequestsOptions extends Indexable {
+  timeField?: PullRequestTimeField;
+  query?: string;
+}
+
+export interface PullRequestReviewsOptions extends Indexable {
   timeField?: PullRequestTimeField;
   query?: string;
 }

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -12,6 +12,7 @@ import QueryEditorCommits from './QueryEditorCommits';
 import QueryEditorIssues from './QueryEditorIssues';
 import QueryEditorMilestones from './QueryEditorMilestones';
 import QueryEditorPullRequests from './QueryEditorPullRequests';
+import QueryEditorPullRequestReviews from './QueryEditorPullRequestReviews';
 import QueryEditorTags from './QueryEditorTags';
 import QueryEditorContributors from './QueryEditorContributors';
 import QueryEditorLabels from './QueryEditorLabels';
@@ -76,6 +77,11 @@ const queryEditors: {
   [QueryType.Pull_Requests]: {
     component: (props: Props, onChange: (val: any) => void) => (
       <QueryEditorPullRequests {...(props.query.options || {})} onChange={onChange} />
+    ),
+  },
+  [QueryType.Pull_Request_Reviews]: {
+    component: (props: Props, onChange: (val: any) => void) => (
+      <QueryEditorPullRequestReviews {...(props.query.options || {})} onChange={onChange} />
     ),
   },
   [QueryType.Vulnerabilities]: {

--- a/src/views/QueryEditorPullRequestReviews.tsx
+++ b/src/views/QueryEditorPullRequestReviews.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Input, Select, InlineField } from '@grafana/ui';
+import { SelectableValue } from '@grafana/data';
+import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import { PullRequestTimeField } from '../constants';
+import type { PullRequestReviewsOptions } from '../types/query';
+
+interface Props extends PullRequestReviewsOptions {
+  onChange: (value: PullRequestReviewsOptions) => void;
+}
+
+const timeFieldOptions: Array<SelectableValue<PullRequestTimeField>> = Object.keys(PullRequestTimeField)
+  .filter((_, i) => PullRequestTimeField[i] !== undefined)
+  .map((_, i) => {
+    return {
+      label: `${PullRequestTimeField[i]}`,
+      value: i as PullRequestTimeField,
+    };
+  });
+
+const defaultTimeField = timeFieldOptions[0].value;
+
+const QueryEditorPullRequestReviews = (props: Props) => {
+  const [query, setQuery] = useState<string>(props.query || '');
+  return (
+    <>
+      <InlineField
+        labelWidth={LeftColumnWidth * 2}
+        label="Query"
+        tooltip={() => (
+          <>
+            For more information, visit&nbsp;
+            <a
+              href="https://docs.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests"
+              target="_blank"
+              rel="noreferrer"
+            >
+              https://docs.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests
+            </a>
+          </>
+        )}
+        interactive={true}
+      >
+        <Input
+          value={query}
+          width={RightColumnWidth}
+          onChange={(el) => setQuery(el.currentTarget.value)}
+          onBlur={(el) =>
+            props.onChange({
+              ...props,
+              query: el.currentTarget.value,
+            })
+          }
+        />
+      </InlineField>
+      <InlineField
+        labelWidth={LeftColumnWidth * 2}
+        label="Time Field"
+        tooltip="The time field to filter on the time range. WARNING: If selecting 'None', be mindful of the amount of data being queried. On larger repositories, querying all pull requests could easily cause rate limiting"
+      >
+        <Select
+          width={RightColumnWidth}
+          options={timeFieldOptions}
+          value={props.timeField || defaultTimeField}
+          onChange={(opt) =>
+            props.onChange({
+              ...props,
+              timeField: opt.value,
+            })
+          }
+        />
+      </InlineField>
+    </>
+  );
+};
+
+export default QueryEditorPullRequestReviews;


### PR DESCRIPTION
Closes #70

This introduces a new query type of Pull Request Reviews. This is separate from Pull Requests due to
adding more paginated queries to handle more than 100 reviews (I imagine this is quite rare) as well as pulling more data.
Combining pull requests and reviews results in a log of duplication that doesn't make sense for other PR use cases.

## Use Case

- Supports the use case documented in #70
- Supports creating a page like Panda's Leaderboard page
